### PR TITLE
37 fix programme overview background colour

### DIFF
--- a/script.js
+++ b/script.js
@@ -75,6 +75,10 @@ fetch('OpenDay.json')
                     showMoreBtn.addEventListener('click', () => {
                         topic.programs.slice(3).forEach(program => {
                             const programDiv = showProgramOverview(program);
+
+                            // Distinguish programme cards added in Show More button from existing classes
+                            programDiv.classList.add('added-program');
+
                             programContainer.appendChild(programDiv);
                         });
                         // Invisible 'Show More Programme' button after click

--- a/style.css
+++ b/style.css
@@ -173,3 +173,7 @@ body {
     object-position: center;
     display: block;
 }
+
+.program-container .added-program {
+    background-color: red;
+}

--- a/style.css
+++ b/style.css
@@ -174,6 +174,10 @@ body {
     display: block;
 }
 
-.program-container .added-program {
-    background-color: red;
+.program-container .added-program:nth-child(2n+1) {
+    background: #f8f8f8;
+}
+
+.program-container .added-program:nth-child(2n) {
+    background-color: transparent;
 }


### PR DESCRIPTION
Apply appropriate colour to added programme overview cards by "Show More" button.

## What I did:
Add class name `added-program` to programme overview cards in `script.js`.  
![image](https://github.com/user-attachments/assets/918fe1b3-152d-42a4-8d0f-70d422d8a499)
  
Apply background colour to `added-program` class in `style.css`  
![image](https://github.com/user-attachments/assets/f43eed5d-ecf3-4d4f-b9de-d6a17a682f67)

## Outcome
![image](https://github.com/user-attachments/assets/fcfe4ab2-1f8f-4ae6-a557-a9fce173ad3c)  
  
![image](https://github.com/user-attachments/assets/4c894eb5-ca93-456b-887f-3aae3c27a3d8)  
-> Cards are still in the correct colour after the "Show More" button.