### PR TITLE
Adjust School and Programme Overview Section Styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -74,17 +74,14 @@ body {
 }
 
 .topic-cover-container {
-    width: 600px;
     aspect-ratio: 16 / 5;
     overflow: hidden;
-    background-color: red;
 }
 
 .topic-cover-container img {
     width: 100%;
     height: 100%;
     object-fit: cover;
-    object-position: center;
     display: block;
 }
 
@@ -92,13 +89,12 @@ body {
     font-size: 1.5rem;
     font-weight: 900;
     color: #363636;
-    margin: 0 1rem;
 }
 
 .program {
     border: 1px solid #eee;
     border-radius: 10px;
-    margin: 1rem;
+    margin: 1rem 0;
     padding: 1.5rem;
 }
 
@@ -150,7 +146,7 @@ body {
     font-weight: 600;
     border: none;
     border-radius: 6px;
-    margin-left: 1.5rem;
+    margin-left: 0 1.5rem;
     padding: 0.4rem 1.0rem;
 }
 
@@ -160,17 +156,14 @@ body {
 }
 
 .location-image-container {
-    width: 600px;
     aspect-ratio: 16 / 5;
     overflow: hidden;
-    background-color: red;
 }
 
 .location-image-container img {
     width: 100%;
     height: 100%;
     object-fit: cover;
-    object-position: center;
     display: block;
 }
 
@@ -180,4 +173,13 @@ body {
 
 .program-container .added-program:nth-child(2n) {
     background-color: transparent;
+}
+
+.topic-title {
+    text-align: center;
+}
+
+.topic-card {
+    width: 70%;
+    margin: 70px auto 0;
 }


### PR DESCRIPTION
## What I did
- Applied styles to centre-align only the school name text, while ensuring that other elements have their containing objects centred instead.  
```css
.topic-title {
    text-align: center;
}

.topic-card {
    width: 70%;
    margin: 70px auto 0;
}
```
  
- Removed debug code

## Outcomes
The UI style is now based on the original Figma design. The widths are aligned, creating a more user-friendly and visually appealing interface.  
![image](https://github.com/user-attachments/assets/b4713a14-593b-4385-a3b6-0d52744ffd27)
