### PR TITLE
Implement popup close functionality on outside click with overlay

### DIFF
--- a/script.js
+++ b/script.js
@@ -159,6 +159,9 @@ fetch('OpenDay.json')
             closeBtn.onclick = () => {
                 overlay.classList.add('hidden');
             };
+            overlay.onclick = () => {
+                overlay.classList.add('hidden');
+            };
         }
 
         // Search and Sort Function

--- a/script.js
+++ b/script.js
@@ -156,12 +156,13 @@ fetch('OpenDay.json')
             overlay.classList.remove('hidden');
 
             // Close Overlay
-            closeBtn.onclick = () => {
+            closeBtn.onclick = () => closeOverlay();
+            overlay.onclick = () => closeOverlay();
+
+            // Add event listener to a function that adds the 'hidden' class
+            function closeOverlay() {
                 overlay.classList.add('hidden');
-            };
-            overlay.onclick = () => {
-                overlay.classList.add('hidden');
-            };
+            }
         }
 
         // Search and Sort Function


### PR DESCRIPTION
## What I did:
- Implemented JavaScript functionality to close the popup when the overlay is clicked.
- Refactor it into a function
```js
            // Close Overlay
            closeBtn.onclick = () => closeOverlay();
            overlay.onclick = () => closeOverlay();

            // Add event listener to a function that adds the 'hidden' class
            function closeOverlay() {
                overlay.classList.add('hidden');
            }
```

## Outcomes:
- Clicking outside the popup (on the overlay) will close the popup window, providing a seamless user experience.