### PR TITLE
Refactor logic for display default text

### DIFF
--- a/script.js
+++ b/script.js
@@ -149,7 +149,10 @@ fetch('OpenDay.json')
                 <p><strong>Building:</strong> ${locationWebsite}</p>
                 <div class="location-image-container">${locationImage}</div>
                 <p> ${program.location?.description || ''}</p>
-                <p> ${program.location?.address || ''}, ${program.location?.postcode || ''}</p>
+                <p>
+                    ${program.location?.address ? `${program.location.address}, ${program.location?.postcode || ''}`
+                    : program.location?.postcode || ''}
+                </p>
                 <p>${mapLink}</p>
             `;
 

--- a/script.js
+++ b/script.js
@@ -145,6 +145,10 @@ fetch('OpenDay.json')
                 <h2>${program.title}</h2>               
                 <p><strong>Time:</strong> ${dateTimeStr}</p>
                 <p><strong>Description:</strong> ${program.description}</p>
+                <p>
+                    ${program?.floor ? `<strong>Floor:</strong> ${program.floor}`
+                    : ''}
+                </p>
                 <p><strong>Room:</strong> ${program.room || 'Information not available'}</p>
                 <p><strong>Building:</strong> ${locationWebsite}</p>
                 <div class="location-image-container">${locationImage}</div>

--- a/script.js
+++ b/script.js
@@ -106,8 +106,8 @@ fetch('OpenDay.json')
                 <div class="program-title"><strong>${program.title}</strong></div>
                 <div>${program.description_short}</div>
                 <div><strong>Time:</strong> ${dateTimeStr}</div>
-                <div><strong>Room:</strong> ${program?.room || 'N/A'}</div>
-                <div><strong>Building:</strong> ${program.location?.title || 'N/A'}</div>
+                <div><strong>Room:</strong> ${program?.room || 'Information not available' }</div>
+                <div><strong>Building:</strong> ${program.location?.title || 'Information not available' }</div>
             `;
 
             // Display Programme Detail
@@ -129,11 +129,11 @@ fetch('OpenDay.json')
 
             const mapLink = program.location?.latitude && program.location?.longitude
                 ? `<a href="https://maps.google.com/maps?ll=${program.location.latitude},${program.location.longitude}&z=17&q=${program.location.latitude},${program.location.longitude}" target="_blank">Open in Google Maps</a>`
-                : 'Location info not available';
+                : '';
 
             const locationWebsite = program.location?.website
                 ? `<a href=${program.location.website} target="_blank">${program.location?.title || 'Building Information'}</a>`
-                : '';
+                : 'Information not available';
 
             const locationImage = program.location?.cover_image
                 ? `<img src=${encodeURI(program.location.cover_image)} alt="A photo of the building where the program will be held">`
@@ -145,11 +145,11 @@ fetch('OpenDay.json')
                 <h2>${program.title}</h2>               
                 <p><strong>Time:</strong> ${dateTimeStr}</p>
                 <p><strong>Description:</strong> ${program.description}</p>
-                <p><strong>Room:</strong> ${program.room || 'Programme room N/A'}</p>
+                <p><strong>Room:</strong> ${program.room || 'Information not available'}</p>
                 <p><strong>Building:</strong> ${locationWebsite}</p>
                 <div class="location-image-container">${locationImage}</div>
-                <p> ${program.location?.description || 'Location Description N/A'}</p>
-                <p> ${program.location?.address || 'Location address N/A'}, ${program.location?.postcode || 'Location Postcode N/A'}</p>
+                <p> ${program.location?.description || ''}</p>
+                <p> ${program.location?.address || ''}, ${program.location?.postcode || ''}</p>
                 <p>${mapLink}</p>
             `;
 


### PR DESCRIPTION
## What I did:
- Updated the display logic for the location to ensure proper formatting.
- Added a check to conditionally display the location information only if it exists, avoiding an unnecessary empty string when the information is missing.
- Ensured that the address and postcode are separated by a comma only if the address is provided.

```js
<p>
    ${program.location?.address ? `${program.location.address}, ${program.location?.postcode || ''}`
    : program.location?.postcode || ''}
</p>
```
- Display appropriate default text for elements where it is better to show that no information is available
```js
<p><strong>Room:</strong> ${program.room || 'Information not available'}</p>
```

- Add the floor information. If this information empty, do not display the floor section.
```js
<p>
    ${program?.floor ? `<strong>Floor:</strong> ${program.floor}`
    : ''}
</p>
```

## Outcomes:
- The location information are displayed correctly with proper formatting even if there is no data
![image](https://github.com/user-attachments/assets/52e979bd-48db-4db1-b233-f890a22c0504)  
![image](https://github.com/user-attachments/assets/5df83f24-9cc2-4e4b-9327-f1bd8431f098)

